### PR TITLE
Make dataset properties enumerable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ export default function elementDatasetPolyfill () {
           const propName = name.substr(5).replace(/-./g, toUpperCase)
 
           Object.defineProperty(map, propName, {
-            enumerable: true,
+            enumerable: descriptor.enumerable,
             get: getter.bind({ value: value || '' }),
             set: setter.bind(element, name)
           })

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ export default function elementDatasetPolyfill () {
           const propName = name.substr(5).replace(/-./g, toUpperCase)
 
           Object.defineProperty(map, propName, {
-            enumerable: this.enumerable,
+            enumerable: true,
             get: getter.bind({ value: value || '' }),
             set: setter.bind(element, name)
           })


### PR DESCRIPTION
The code looks like it meant to do this, but `this` in the context it is executed is the element, which does not have an `enumerable` property (at least in IE10, which I was using to manually test this change). Perhaps this is meant to read `descriptor.enumerable`? In any case, this change (or explicitly setting to `true`) was necessary for IE10 to be able to enumerate the dataset.